### PR TITLE
add confluent mappings

### DIFF
--- a/default_category_mappings.json
+++ b/default_category_mappings.json
@@ -290,6 +290,9 @@
         ],
         "mongoatlas": [
             "Data Transfer"
+        ],
+        "confluent": [
+            "Kafka Network"
         ]
     },
     "Security, Identity, & Compliance": {
@@ -362,6 +365,9 @@
         "mongoatlas": [
             "Atlas Cloud Backup Storage",
             "Atlas Storage"
+        ],
+        "confluent": [
+            "Kafka Storage"
         ]
     },
     "Front-End Web & Mobile": {
@@ -393,6 +399,11 @@
             "Cloud Profiler",
             "Cloud Trace",
             "Google Cloud Backup and DR"
+        ]
+    },
+    "Integration": {
+        "confluent": [
+            "Kafka Base"
         ]
     }
 }


### PR DESCRIPTION
I see this error in version "0.1.12":

Backend:
```
[1] 2024-10-01T11:44:47.856Z infrawallet debug Kafka Base does not belong to any category, do a regex search in the category mappings 
[1] 2024-10-01T11:44:47.857Z infrawallet error TypeError: Cannot set properties of undefined (setting 'Kafka Base'
```

Frontend:
![image](https://github.com/user-attachments/assets/c0f90898-b2a2-4bfa-bff7-2467c7fc987e)

I believe it is due to the lack of this mapping.